### PR TITLE
AttributeError: '_tkinter.tkapp' object has no attribute 'mainloo'. Did you mean: 'mainloop'?

### DIFF
--- a/Shodan_GUI_App.py
+++ b/Shodan_GUI_App.py
@@ -665,4 +665,4 @@ if __name__ == "__main__":
         style.configure("TNotebook.Tab", padding=[10, 5], font=('Helvetica', 10))
         style.configure("TButton", padding=6, relief="flat", background="#ccc")
     app = ShodanGUI(root)
-    root.mainloo
+    root.mainloop


### PR DESCRIPTION
Fixed typo: changed root.mainloo to root.mainloop() to resolve AttributeError in Tkinter GUI startup.